### PR TITLE
Update make_todo.gemspec

### DIFF
--- a/make_todo.gemspec
+++ b/make_todo.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "httparty"
+  spec.add_runtime_dependency "httparty"
 end


### PR DESCRIPTION
httparty is a runtime dependency as you can see on the readme, instead of asking to install the gem, we can require it as dependency and avoid having breaking Gemfiles
